### PR TITLE
fix: カラムタイプBIGINTをINTへ修正 / Insertテキストを固定に変更

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -3,11 +3,11 @@ DROP TABLE IF EXISTS test_table;
 CREATE TABLE test_table
 (
     id         INTEGER PRIMARY KEY AUTOINCREMENT ,
-    post_id    BIGINT,
+    post_id    INT,
     short_text VARCHAR,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    sample_id  BIGINT NOT NULL DEFAULT 0 NOT NULL
+    sample_id  INT NOT NULL DEFAULT 0 NOT NULL
 );
 CREATE INDEX index_test_table_on_post_id ON test_table (post_id);
 CREATE INDEX index_test_table_on_sample_id ON test_table (sample_id);

--- a/src/d1.rs
+++ b/src/d1.rs
@@ -135,7 +135,7 @@ impl BulkInsertParams {
 
 impl D1 {
     pub async fn bulk_insert(&self, params: BulkInsertParams) -> Result<QueryResult> {
-        let statement = self.db.prepare("WITH RECURSIVE temp(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM temp WHERE x<?) INSERT INTO test_table (post_id, short_text, sample_id) SELECT CAST(RANDOM() * ? AS BIGINT), SUBSTR(RANDOMBLOB(16), 1, 32), CAST(RANDOM() * ? AS BIGINT) FROM temp;");
+        let statement = self.db.prepare("WITH RECURSIVE temp(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM temp WHERE x<?) INSERT INTO test_table (post_id, short_text, sample_id) SELECT CAST(RANDOM() * ? AS INT), 'sample_text', CAST(RANDOM() * ? AS INT) FROM temp;");
         let query = statement
             .bind(&params.js_values()?)
             .or(Err(anyhow!("failed generate query")))?;


### PR DESCRIPTION
# Summary
表題の通り、
- test_tableのddl内に定義したBIGINTカラムの型定義をINTに変更
- testスクリプトのinsertのクエリのtextを固定に変更